### PR TITLE
Generate symbol files in metal_binary when compilation mode is dbg

### DIFF
--- a/metal.bzl
+++ b/metal.bzl
@@ -79,6 +79,8 @@ def _metal_binary_impl(ctx):
         args.add("-o", air_file)
         args.add("-I./")  # Enable absolute paths
         args.add(src_metal.path)
+        if ctx.var["COMPILATION_MODE"] == "dbg":
+            args.add("-frecord-sources=flat")
 
         apple_support.run(
             actions = ctx.actions,


### PR DESCRIPTION
Hi, first off, thanks so much for these very simple and very useful rules! I'm finding it useful to be able to use the Xcode Metal debugger with captures from my app when I build with "-c dbg".